### PR TITLE
Use reproject_shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Use `reproject_shape` instead of `reproject_geom` ([#9](https://github.com/stactools-packages/pointcloud/pull/9))
+
+[Unreleased]: <https://github.com/stactools-packages/ephemeral/tree/main/>

--- a/src/stactools/pointcloud/stac.py
+++ b/src/stactools/pointcloud/stac.py
@@ -7,8 +7,8 @@ from pyproj import CRS
 from pystac import Asset, Item
 from pystac.extensions.pointcloud import PointcloudExtension, Schema, Statistic
 from pystac.extensions.projection import ProjectionExtension
-from shapely.geometry import box, mapping, shape
-from stactools.core.projection import reproject_geom
+from shapely.geometry import box, mapping
+from stactools.core.projection import reproject_shape
 
 
 def create_item(
@@ -62,17 +62,17 @@ def create_item(
     spatialreference = CRS.from_string(metadata["spatialreference"])
     original_bbox = box(metadata["minx"], metadata["miny"], metadata["maxx"],
                         metadata["maxy"])
-    geometry = reproject_geom(spatialreference,
-                              "EPSG:4326",
-                              mapping(original_bbox),
-                              precision=6)
-    bbox = list(shape(geometry).bounds)
+    geometry = reproject_shape(spatialreference,
+                               "EPSG:4326",
+                               original_bbox,
+                               precision=6)
+    bbox = geometry.bounds
     dt = datetime.datetime(
         metadata["creation_year"], 1,
         1) + datetime.timedelta(metadata["creation_doy"] - 1)
 
     item = Item(id=id,
-                geometry=geometry,
+                geometry=mapping(geometry),
                 bbox=bbox,
                 datetime=dt,
                 properties={})


### PR DESCRIPTION
## Description

This cleans up some deprecation warnings in tests.

## Checklist

- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Examples have been updated to reflect changes, if applicable
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md), if applicable
